### PR TITLE
Update to v4.1.0 with some minor fixes

### DIFF
--- a/vbox/tty2monitor/dump_atlas_logs
+++ b/vbox/tty2monitor/dump_atlas_logs
@@ -9,18 +9,15 @@ main_log_name="log.EVNTtoHITS"
 athena_log_name="AthenaMP.log"
 athena_workers_dir="athenaMP-workers-EVNTtoHITS-sim"
 
-# use "install -d" instead of mkdir, chown, chmod
-install -d -o montty2 -g montty2 -m 777 ${target_location}
-
 
 # trigger 1: until main log exists
 while :
 do
     main_log="$(find -L ${source_location} -name "${main_log_name}")"
-    [[ "${main_log}" != "" ]] && break
+    [[ "${main_log}" ]] && break
 
-    # check all 10 s (we are not in a hurry)
-    sleep 10
+    # check all 17 s (we are not in a hurry)
+    sleep 17
 done
 
 # tail complete file starting at line 1
@@ -30,12 +27,12 @@ tail -f -n +1 ${main_log} >${target_location}/${main_log_name} 2>/dev/null &
 # check if ATLAS is running singlecore or multicore
 
 # wait until maxEvents appears in main_log
-grep -E -m 1 -s "^.*maxEvents =[^0-9]*[0-9]+" <(tail -F -n +1 --pid ${$} ${main_log} 2>/dev/null) 2>/dev/null
+grep -E -m 1 -s "^.*maxEvents =[^0-9]*[0-9]+" <(tail -F -n +1 --pid ${$} ${target_location}/${main_log_name} 2>/dev/null) 2>/dev/null
 
 # it's a multicore if ATHENA_PROC_NUMBER is in the log before maxEvents
 # it's a singlecore if ATHENA_PROC_NUMBER is missing
 pattrn="^.*ATHENA_PROC_NUMBER set to[^0-9]*"
-n_workers="$(sed -e "0,/${pattrn}/ s/${pattrn}\([0-9]\+\).*/\1/p" -n ${main_log})"
+n_workers="$(sed -e "0,/${pattrn}/ s/${pattrn}\([0-9]\+\).*/\1/p" -n ${target_location}/${main_log_name})"
 [[ ! "${n_workers}" ]] && n_workers="1"
     
 # singlecore logs to main_log

--- a/vbox/tty2monitor/moni_on_tty2
+++ b/vbox/tty2monitor/moni_on_tty2
@@ -80,6 +80,23 @@ function format_timestring {
 }
 
 
+function get_rntme_min_max {
+    local rntme_arr=("${@}")
+
+    # min and max runtimes
+    rntme_min="${rntme_arr[0]}"
+    rntme_max="${rntme_arr[0]}"
+            
+    for rt in "${rntme_arr[@]}"
+    do
+        (( rt < rntme_min )) && rntme_min="${rt}"
+        (( rt > rntme_max )) && rntme_max="${rt}"
+    done
+            
+    echo "${rntme_min} / ${rntme_max} s"
+}
+
+
 function update_display_on_tty {
     # formatted output starts here
     # screen is already blank
@@ -94,7 +111,7 @@ function update_display_on_tty {
     printf "\033[0;0H"
     printf "***************************************************\033[K\n"
     printf "*         \033[1mATLAS Event Progress Monitoring\033[0m         *\033[K\n"
-    printf "*                     v4.0.0                      *\033[K\n"
+    printf "*                     v4.1.0                      *\033[K\n"
 
     if [[ "${1}" == "starting" ]]
     then
@@ -248,17 +265,8 @@ do
             # don't do this outside "if" as it would overwrite "N/A"
             n_finished_events="${#rntme_arr[@]}"
             
-            # min and max runtimes
-            rntme_min="${rntme_arr[0]}"
-            rntme_max="${rntme_arr[0]}"
-            
-            for rt in "${rntme_arr[@]}"
-            do
-                (( rt < rntme_min )) && rntme_min="${rt}"
-                (( rt > rntme_max )) && rntme_max="${rt}"
-            done
-            
-            rntme_min_max="${rntme_min} / ${rntme_max} s"
+            # runtimes: minimum and maximum values
+            rntme_min_max="$(get_rntme_min_max "${rntme_arr[@]}")"
 
             # runtimes: global arithmetic mean
             rntme_arth_mean="$(awk '{ sum=0; for (i=1; i<=NF; i++) { sum+=$i } printf "%f", sum/NF }' <<< "${rntme_arr[@]}")"

--- a/vbox/tty2monitor/override.conf
+++ b/vbox/tty2monitor/override.conf
@@ -3,7 +3,7 @@ Description=ATLAS (vbox) Event Monitoring - Foreground Service
 BindsTo=atlasmonitoring_bg.service
 
 [Service]
-ExecStartPre=/bin/rm -rf /home/montty2/RunAtlas
+ExecStartPre=/bin/rm -rf /home/montty2/RunAtlas/*
 ExecStart=
 ExecStart=/sbin/agetty --autologin montty2 %I $TERM
 RestartSec=2

--- a/vbox/tty2monitor/setup_moni_on_tty2
+++ b/vbox/tty2monitor/setup_moni_on_tty2
@@ -39,6 +39,9 @@ then
     chpasswd <<< "${user_on_tty}:$(head -c 1 < <(tr -cd a-zA-Z < /dev/urandom))$(head -c ${pw_length} < <(tr -cd a-zA-Z0-9$%/=+~*#_,. < /dev/urandom))$(head -c 1 < <(tr -cd a-zA-Z0-9 < /dev/urandom))" 2>/dev/null
 fi
 
+# create target directory to write the logfile dumps to
+install -d -o ${user_on_tty} -g ${user_on_tty} -m 777 /home/${user_on_tty}/RunAtlas
+
 
 # install commands from above are running in the background
 # ensure they have finished
@@ -50,5 +53,8 @@ systemctl daemon-reload
 if [[ "$(systemctl show -p ActiveState getty@tty2.service)" != "ActiveState=inactive" ]] ||
    [[ "$(systemctl show -p ActiveState atlasmonitoring_bg.service)" != "ActiveState=inactive" ]]
 then
-    systemctl restart getty@tty2.service
+    # a "systemctl restart ..." does NOT restart the bg service
+    # hence it MUST be "systemctl stop ..." followed by "systemctl start ..."
+    systemctl stop getty@tty2.service
+    systemctl start getty@tty2.service
 fi

--- a/vbox/tty3monitor/setup_top_on_tty3
+++ b/vbox/tty3monitor/setup_top_on_tty3
@@ -52,4 +52,8 @@ wait
 # activate the getty override.conf
 systemctl daemon-reload
 
-[[ "$(systemctl show -p ActiveState getty@tty3.service)" != "ActiveState=inactive" ]] && systemctl restart getty@tty3.service
+if [[ "$(systemctl show -p ActiveState getty@tty3.service)" != "ActiveState=inactive" ]]
+then
+    systemctl stop getty@tty3.service
+    systemctl start getty@tty3.service
+fi


### PR DESCRIPTION
Changes:

Moved the creation of /home/montty2/RunAtlas from dump_atlas_logs to setup_moni_on_tty2 since this directory is used in the fg service as well as in the bg service.

Created a function get_rntme_min_max in moni_on_tty2 to keep the main loop lean and clearly arranged.

Fixed a bug in setup_moni_on_tty2 that prevented the bg service to restart together with the fg service.


A couple of minor changes in various files.