### PR TITLE
Log Message from cvmfs_config

### DIFF
--- a/native/run_atlas.sh
+++ b/native/run_atlas.sh
@@ -62,6 +62,7 @@ else
     cleanexit 1
   fi
 fi
+echo "$cvmfs_config_stat"
 echo "CVMFS is ok"
 
 # check from cvmfs_config output whether openhtc is used and whether a local proxy is used.


### PR DESCRIPTION
Ensures output of cvmfs_config stat is printed to the log.
This is used to check for weird proxy settings.