### PR TITLE
add service dependencies

### DIFF
--- a/vbox/atlas-app.service
+++ b/vbox/atlas-app.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=ATLAS job
-Requires=autofs.service
-After=network.target autofs.service
+Requires=autofs.service vboxguest.service
+After=network.target autofs.service vboxguest.service
 
 [Service]
 User=atlas

--- a/vbox/atlas-app.service
+++ b/vbox/atlas-app.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=ATLAS job
 Requires=autofs.service vboxguest.service
-After=network.target autofs.service vboxguest.service
+Wants=httpd.service
+After=network.target autofs.service vboxguest.service httpd.service
 
 [Service]
 User=atlas


### PR DESCRIPTION
vboxquest service must be present before ATLAS can mount the shared folder.
Requires a new app_version.
