### PR TITLE
Update default CVMFS_SERVER_URL

### DIFF
--- a/vbox/etc/cvmfs/domain.d/cern.ch.local
+++ b/vbox/etc/cvmfs/domain.d/cern.ch.local
@@ -1,1 +1,16 @@
 CVMFS_CONFIG_REPO_REQUIRED=yes
+
+# The CVMFS_CONFIG_REPO_DEFAULT_ENV parameter is set in
+# /cvmfs/cvmfs-config.cern.ch/etc/cvmfs/default.conf
+if [ "$CVMFS_CONFIG_REPO_DEFAULT_ENV" = "" ]; then
+  # Use the configuration in this package only if the config repository is not
+  # mounted. Note that in this case the cvmfs client writes a warning to syslog
+  # because CVMFS_CONFIG_REPOSITORY is set.
+
+  # Stratum 1 servers for the cern.ch domain.
+  if [ "$CVMFS_USE_CDN" = "yes" ]; then
+    CVMFS_SERVER_URL="http://s1cern-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1ral-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1asgc-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1ihep-cvmfs.openhtc.io:8080/cvmfs/@fqrn@;http://s1swinburne-cvmfs.openhtc.io:8080/cvmfs/@fqrn@"
+  else
+    CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch:8000/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk:8000/cvmfs/@fqrn@;http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfsrep.grid.sinica.edu.tw:8000/cvmfs/@fqrn@;http://cvmfs-stratum-one.ihep.ac.cn:8000/cvmfs/@fqrn@;http://cvmfs-s1.hpc.swin.edu.au:8000/cvmfs/@fqrn@"
+  fi
+fi


### PR DESCRIPTION
Replace CVMFS_SERVER_URL from the cvmfs-config package with the recent servers from the online config repository. This change ensures the online config repository also uses the recent servers at startup.